### PR TITLE
Initialize support for silica function translator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 astor
 graphviz
-git+git://github.com/phanrahan/magma.git#egg=magma
+git+git://github.com/phanrahan/magma.git#egg=magma@ssa
 git+git://github.com/phanrahan/mantle.git#egg=mantle
 git+git://github.com/phanrahan/loam.git#egg=loam
 coreir

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 astor
 graphviz
-git+git://github.com/phanrahan/magma.git#egg=magma@ssa
+git+git://github.com/phanrahan/magma.git@ssa#egg=magma
 git+git://github.com/phanrahan/mantle.git#egg=mantle
 git+git://github.com/phanrahan/loam.git#egg=loam
 coreir

--- a/silica/__init__.py
+++ b/silica/__init__.py
@@ -1,4 +1,5 @@
 from .coroutine import coroutine, Coroutine, generator, Generator
+from .function import function, compile_function
 from .compile import compile
 from ._config import Config
 config = Config()

--- a/silica/function.py
+++ b/silica/function.py
@@ -1,0 +1,66 @@
+import types
+import magma as m
+import silica.verilog as verilog
+import inspect
+from silica.visitors import collect_stores
+from silica.analysis import CollectInitialWidthsAndTypes
+from silica.type_check import to_type_str
+from silica.width import get_io_width
+import ast
+import veriloggen as vg
+
+
+class ReturnReplacer(ast.NodeTransformer):
+    def visit_Return(self, node):
+        if isinstance(node.value, ast.Tuple):
+            raise NotImplementedError()
+        return ast.Assign([ast.Name("O", ast.Store())], node.value)
+
+
+def function(fn : types.FunctionType):
+    """ TODO: Do implicit conversion of Python types to BitVector """
+    return fn
+
+
+def compile_function(fn : types.FunctionType, file_name : str):
+    stack = inspect.stack()
+    func_locals = stack[1].frame.f_locals
+    func_globals = stack[1].frame.f_globals
+    tree = m.ast_utils.get_func_ast(fn)
+    ctx = verilog.Context(tree.name)
+    width_table = {}
+    type_table = {}
+
+    def get_len(t):
+        try:
+            return len(t)
+        except Exception:
+            return 1
+
+
+    inputs = inspect.getfullargspec(fn).annotations
+    for input_, type_ in inputs.items():
+        type_table[input_] = to_type_str(type_)
+        width_table[input_] = get_io_width(type_)
+
+    inputs = { i : get_len(t) for i,t in inputs.items() }
+    output = inspect.signature(fn).return_annotation
+    assert not isinstance(output, tuple), "Not implemented"
+    type_table["O"] = to_type_str(output)
+    width_table["O"] = get_io_width(output)
+    outputs = { "O" : get_len(output) }
+
+    CollectInitialWidthsAndTypes(width_table, type_table, func_locals, func_globals).visit(tree)
+
+    ctx.declare_ports(inputs, outputs)
+
+    stores = collect_stores(tree)
+    for store in stores:
+        ctx.declare_wire(store, width_table[store])
+
+    tree = ReturnReplacer().visit(tree)
+
+    ctx.module.Always(vg.SensitiveAll())([ctx.translate(s) for s in tree.body])
+
+    with open(file_name, "w") as f:
+        f.write(ctx.to_verilog())

--- a/silica/type_check.py
+++ b/silica/type_check.py
@@ -6,11 +6,11 @@ import magma as m
 
 def to_type_str(type_):
     if isinstance(type_, m.BitKind):
-        type_ = "bit"
+        return "bit"
     elif isinstance(type_, m.UIntKind):
-        type_ = "uint"
+        return "uint"
     elif isinstance(type_, m.BitsKind):
-        type_ = "bits"
+        return "bits"
     else:
         raise NotImplementedError(type_)
 

--- a/silica/type_check.py
+++ b/silica/type_check.py
@@ -1,6 +1,18 @@
 import ast
 from .width import get_width
 import astor
+import magma as m
+
+
+def to_type_str(type_):
+    if isinstance(type_, m.BitKind):
+        type_ = "bit"
+    elif isinstance(type_, m.UIntKind):
+        type_ = "uint"
+    elif isinstance(type_, m.BitsKind):
+        type_ = "bits"
+    else:
+        raise NotImplementedError(type_)
 
 
 class TypeChecker(ast.NodeVisitor):

--- a/silica/verilog.py
+++ b/silica/verilog.py
@@ -12,7 +12,7 @@ from .memory import MemoryType
 from .cfg.util import find_branch_join
 
 class Context:
-    def __init__(self, name, sub_coroutines):
+    def __init__(self, name, sub_coroutines=[]):
         self.module = vg.Module(name)
         self.sub_coroutines = sub_coroutines
 
@@ -117,9 +117,14 @@ class Context:
             return vg.Eq
         elif is_if(stmt):
             body = [self.translate(stmt) for stmt in stmt.body]
-            return vg.If(
+            if_ = vg.If(
                 self.translate(stmt.test),
             )(body)
+            if stmt.orelse:
+                if_.Else(
+                    [self.translate(stmt) for stmt in stmt.orelse]
+                )
+            return if_
         elif is_if_exp(stmt):
             return vg.Cond(
                 self.translate(stmt.test),

--- a/silica/width.py
+++ b/silica/width.py
@@ -116,3 +116,19 @@ def get_width(node, width_table, func_locals={}, func_globals={}):
 
 
     raise NotImplementedError(ast.dump(node))
+
+
+def get_io_width(type_):
+    if type_ is m.Bit:
+        return None
+    elif isinstance(type_, m.ArrayKind):
+        if isinstance(type_.T, m.ArrayKind):
+            elem_width = get_io_width(type_.T)
+            if isinstance(elem_width, tuple):
+                return (type_.N, ) + elem_width
+            else:
+                return (type_.N, elem_width)
+        else:
+            return type_.N
+    else:
+        raise NotImplementedError(type_)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,6 +1,8 @@
 import silica as si
 
 
+# TODO: These were adapted from magma's SSA tests, perhaps we can find a nice
+# way to reuse test functions?
 def test_basic():
     @si.function
     def basic_if(I: si.Bits(2), S: si.Bit) -> si.Bit:
@@ -32,6 +34,98 @@ module basic_if
       x = I[0];
     end else begin
       x = I[1];
+    end
+    O = x;
+  end
+
+
+endmodule
+
+"""
+
+
+def test_default():
+    @si.function
+    def default(I: si.Bits(2), S: si.Bit) -> si.Bit:
+        x = I[1]
+        if S:
+            x = I[0]
+        return x
+
+    si.compile_function(default, file_name="tests/build/default.v")
+    with open("tests/build/default.v", "r") as f:
+        result = f.read()
+        print(result)
+        assert result == """\
+
+
+module default
+(
+  output O,
+  input return,
+  input [2-1:0] I,
+  input S
+);
+
+  wire x;
+
+  always @(*) begin
+    x = I[1];
+    if(S) begin
+      x = I[0];
+    end 
+    O = x;
+  end
+
+
+endmodule
+
+"""
+
+
+def test_nested():
+    @si.function
+    def nested(I: si.Bits(4), S: si.Bits(2)) -> si.Bit:
+        if S[0]:
+            if S[1]:
+                x = I[0]
+            else:
+                x = I[1]
+        else:
+            if S[1]:
+                x = I[2]
+            else:
+                x = I[3]
+        return x
+
+    si.compile_function(nested, file_name="tests/build/nested.v")
+    with open("tests/build/nested.v", "r") as f:
+        result = f.read()
+        print(result)
+        assert result == """\
+
+
+module nested
+(
+  output O,
+  input return,
+  input [4-1:0] I,
+  input [2-1:0] S
+);
+
+  wire x;
+
+  always @(*) begin
+    if(S[0]) begin
+      if(S[1]) begin
+        x = I[0];
+      end else begin
+        x = I[1];
+      end
+    end else if(S[1]) begin
+      x = I[2];
+    end else begin
+      x = I[3];
     end
     O = x;
   end

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -1,0 +1,42 @@
+import silica as si
+
+
+def test_basic():
+    @si.function
+    def basic_if(I: si.Bits(2), S: si.Bit) -> si.Bit:
+        if S:
+            x = I[0]
+        else:
+            x = I[1]
+        return x
+
+    si.compile_function(basic_if, file_name="tests/build/basic_if.v")
+    with open("tests/build/basic_if.v", "r") as f:
+        result = f.read()
+        print(result)
+        assert result == """\
+
+
+module basic_if
+(
+  output O,
+  input return,
+  input [2-1:0] I,
+  input S
+);
+
+  wire x;
+
+  always @(*) begin
+    if(S) begin
+      x = I[0];
+    end else begin
+      x = I[1];
+    end
+    O = x;
+  end
+
+
+endmodule
+
+"""


### PR DESCRIPTION
This PR tracks an effort to provide support in the Silica compiler
for compiling pure Python functions to Verilog. This leverages
the existing Verilog backend used by the coroutine compiler
pipeline. There's still some work to clean up and organize how
we're doing this, but this serves as a minimum working example.